### PR TITLE
Datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ OTPQA
 2. Run tests against host `docker run -p8000:8000 -e TARGET_HOST=dev-api.digitransit.fi hsldevcom/otpqa`
 3. Check results: http://localhost:8000/report.html
 
+
 ## Original OTPQA docs
 
 Keep track of changes in OTP performance as development progresses, and catch breaking changes to input data sets by observing changes in routing results.
@@ -45,3 +46,19 @@ To generate a report run
 To generate an HTML report, run
 
     $ python hreport.py f1 [fn2 [fn3 ...]] > report.html
+
+
+## Routing performance and regression detection
+
+Generate a benchmark file:
+
+    $ python otpprofiler.py hostname
+
+When data or OTP changes, generate a test file:
+
+    $ python otpprofiler.py hostname
+
+Then run comparison:
+
+    $ python compare.py benchmark_profile.json new_profile.json
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OTPQA
 
 Keep track of changes in OTP performance as development progresses, and catch breaking changes to input data sets by observing changes in routing results.
 
-You will need Python and some Python libraries. For the libraries, on a Debian based system like Ubuntu you can run:
+You will need Python (2.x) and some Python libraries. For the libraries, on a Debian based system like Ubuntu you can run:
 
 `$ sudo apt-get install python-simplejson python-scipy`
 
@@ -43,10 +43,11 @@ To generate a report run
 
     $ python report.py filename1.json filename2.json
 
+Where a file name corresponds to a run_summary file created earlier
+
 To generate an HTML report, run
 
     $ python hreport.py f1 [fn2 [fn3 ...]] > report.html
-
 
 ## Routing performance and regression detection
 
@@ -61,4 +62,3 @@ When data or OTP changes, generate a test file:
 Then run comparison:
 
     $ python compare.py benchmark_profile.json new_profile.json
-

--- a/compare.py
+++ b/compare.py
@@ -15,7 +15,7 @@ def extractdurations(filename):
         for id_tuple in dataset:
                 response = dataset[id_tuple]
 
-                if len(response["itins"]) == 0:
+                if not "itins" in response or len(response["itins"]) == 0:
                         durations[id_tuple] = -1
                 else:
 			durations[id_tuple] = parsetime( response["itins"][0]["duration"] )
@@ -32,7 +32,7 @@ def main(filenames):
         count = 0
 
 	for id in dur1:
-                if not id in dur1 or not id in dur2:
+                if not id in dur2:
                         print "test data is not comparable"
                         exit()
                 t1 = dur1[id]

--- a/compare.py
+++ b/compare.py
@@ -34,7 +34,8 @@ def main(filenames):
 	for id in dur1:
                 t1 = dur1[id]
                 t2 = dur2[id]
-
+                if t1 != t2:
+                        print "Test %s t1=%d t2=%d"%(id, t1, t2)
                 if t1 < 0 and t2 > 0:
                         fails1+=1
                 elif t1 > 0 and t2 < 0:

--- a/compare.py
+++ b/compare.py
@@ -32,6 +32,9 @@ def main(filenames):
         count = 0
 
 	for id in dur1:
+                if not id in dur1 or not id in dur2:
+                        print "test data is not comparable"
+                        exit()
                 t1 = dur1[id]
                 t2 = dur2[id]
                 if t1 != t2:

--- a/otpprofiler.py
+++ b/otpprofiler.py
@@ -164,7 +164,7 @@ def summarize_plan (itinerary) :
             waits.append(wait)
     ret = {
         'start_time' : time.asctime(time.gmtime(itinerary['startTime'] / 1000)) + ' GMT',
-        'duration' : '%d msec' % int(itinerary['duration']),
+        'duration' : '%d sec' % int(itinerary['duration']),
         'n_legs' : n_legs,
         'n_vehicles' : n_vehicles,
         'walk_distance' : itinerary['walkDistance'],

--- a/otpprofiler.py
+++ b/otpprofiler.py
@@ -13,6 +13,8 @@ from random import randint, seed
 # python-requests wraps urllib2 providing a much nicer API.
 import grequests
 
+TIME='14:00:00'
+
 # generate test date on a recent/upcoming monday. Use a fixed work day to keep results comparable
 cdate = date.today()
 dd = cdate.day - cdate.weekday() # monday = 0. want monday!
@@ -20,8 +22,6 @@ if dd < 1:
     dd = dd + 7 # use next monday
 
 DATE = "%s-%s-%s"%(cdate.year, cdate.month, dd)
-
-print "TEST DATE:", DATE
 
 # split out base and specific endpoint
 SHOW_PARAMS = False
@@ -331,6 +331,11 @@ def run(connect_args) :
     count = connect_args.pop('count')
     host = connect_args.pop('host')
     profile = connect_args.pop('profile')
+    Date = connect_args.pop('date')
+    Time = connect_args.pop('time')
+
+    print "TEST DATE:", Date, Time
+
     print("profile=%s"%profile)
     # info = getServerInfo(host)
     # while retry > 0 and info == None:
@@ -349,7 +354,6 @@ def run(connect_args) :
     run_json = dict(zip(('notes','id'), run_row))
 
     all_params = get_params(fast, count)
-    random.shuffle(all_params)
     global t0, N # HACK
     t0 = time.time()
     N = len(all_params)
@@ -360,7 +364,8 @@ def run(connect_args) :
         oid = params.pop('oid')
         tid = params.pop('tid')
 
-        params['date'] = DATE
+        params['date'] = Date
+        params['time'] = Time
         if profile:
             api_method = 'profile'
             params['from'] = params.pop('fromPlace')
@@ -369,7 +374,7 @@ def run(connect_args) :
             params['limit'] = 3
         else:
             api_method = 'plan'
-            params['numItineraries'] = 3
+            params['numItineraries'] = 1
 
         qstring = urllib.urlencode(params)
 
@@ -427,6 +432,8 @@ if __name__=="__main__":
     parser.add_argument('host')
     parser.add_argument('-f', '--fast', action='store_true', default=False)
     parser.add_argument('-n', '--notes')
+    parser.add_argument('-d', '--date', default=DATE)
+    parser.add_argument('-t', '--time', default='14:00')
     parser.add_argument('-r', '--retry', type=int, default=5)
     parser.add_argument('-c', '--count', type=int, default=1100)
     parser.add_argument('-p', '--profile', action='store_true', default=False)

--- a/result_plot_from_file.py
+++ b/result_plot_from_file.py
@@ -1,0 +1,25 @@
+import json, violin
+
+def plot_results(dataset, label):
+
+    data = []
+    total_times = []
+
+    if "responses" in dataset:
+        for resp in dataset['responses']:
+            if "total_time" in resp:
+                total_times.append( float(resp["total_time"][:-5]) / 1000.00) #to seconds
+
+        data.append(total_times)
+        violin.violin_plot(data, bp=True, scale=True, labels=[label])
+
+
+if __name__=='__main__':
+    import sys
+
+    if len(sys.argv)<3:
+        print "usage: cmd json_summary_file_name plot_label"
+        exit()
+
+    dataset = json.load(open(sys.argv[1]))
+    plot_results(dataset, sys.argv[2])


### PR DESCRIPTION
- Fix test time so that it is easy to repeat comparable routing tests (previously used current time)
- Add d=yyyy-mm-dd and t=hh:mm params to otpprofiler.py. Exact routing test time can be set easily.
